### PR TITLE
Add user in final stage and use it to copy data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ ENV GO111MODULE=on
 RUN apk update && \
   apk add bash ca-certificates git gcc g++ libc-dev
 
-RUN adduser -D -g '' testapp
-
 COPY go.mod /src/testapp/
 COPY go.sum /src/testapp/
 WORKDIR /src/testapp/
@@ -22,7 +20,9 @@ FROM alpine
 
 COPY --from=builder /etc/passwd /etc/passwd
 
-COPY data/ /data
+RUN adduser -D -g '' testapp
+
+COPY --chown=testapp data/ /data
 
 EXPOSE 9000
 


### PR DESCRIPTION
Without this PR following instructions in https://github.com/stormforger/testapp#usage would lead to container failing to start with:

```
$ docker run --rm -p 8080:8080 -p 8443:8443 stormforger/testapp
Unable to find image 'stormforger/testapp:latest' locally
latest: Pulling from stormforger/testapp
9d48c3bd43c5: Pull complete 
77e49ee87f70: Pull complete 
c85978bc6114: Pull complete 
61355d1001c7: Pull complete 
Digest: sha256:0ad6169c56ee516fe444b8233b7471052e74853f63206652c693f2de1b4bb8b2
Status: Downloaded newer image for stormforger/testapp:latest
time="2020-04-04T13:57:49Z" level=warning msg="SHUTDOWN_CODE not configured!"
time="2020-04-04T13:57:49Z" level=fatal msg="open data/pki/server.key.pem: permission denied"
```