### PR TITLE
feat: show tls version in /x509/inspect endpoint

### DIFF
--- a/server/x509.go
+++ b/server/x509.go
@@ -23,6 +23,7 @@ type tlsInspect struct {
 	ServerName string `json:"server_name,omitempty"`
 	Status     string `json:"status,omitempty"`
 	Subject    string `json:"subject,omitempty"`
+	TLSversion string `json:"tls_version,omitempty"`
 }
 
 type x509Handlers struct {
@@ -62,6 +63,7 @@ func clientCertInspectHandler(w http.ResponseWriter, r *http.Request) {
 
 	tlsInspection := &tlsInspect{
 		ServerName: r.TLS.ServerName,
+		TLSversion: fmt.Sprintf("1.%d", r.TLS.Version&0x0F-1),
 	}
 
 	if len(certs) == 0 {


### PR DESCRIPTION
Expose the TLS version, if connected via TLS in the `/x509/inspect` endpoint.

### Caveats

It's an ugly hack to format the tls version number, but I wanted to avoid a big switch statement.