### PR TITLE
Add ReadRequestBodyMiddleware which reads the request body

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,16 +9,10 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
 
-    - name: Read go version
-      id: read_versions
-      run: |
-        echo "::set-output name=go::$(go mod edit -json | jq -r .Go)"
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "${{ steps.read_versions.outputs.go }}"
-      id: go
+        go-version-file: "go.mod"
 
     - name: Get dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,22 @@
 # STEP 1 build executable binary
 FROM golang:alpine as builder
 
-ENV GO111MODULE=on
+COPY . /src/testapp/
 
-RUN apk update && \
-  apk add bash ca-certificates git gcc g++ libc-dev
-
-COPY go.mod /src/testapp/
-COPY go.sum /src/testapp/
 WORKDIR /src/testapp/
 
-RUN go mod download
-
-COPY . /src/testapp/
 RUN go build -o /testapp
 
 # STEP 2 build a small image
 FROM alpine
 
-COPY --from=builder /etc/passwd /etc/passwd
-
 RUN adduser -D -g '' testapp
 
+COPY --from=builder /testapp /testapp
 COPY --chown=testapp data/ /data
-
-EXPOSE 9000
 
 USER testapp
 
-ENTRYPOINT ["/testapp"]
+EXPOSE 9000
 
-COPY --from=builder /testapp /testapp
+ENTRYPOINT ["/testapp"]

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,12 @@ require (
 	github.com/stretchr/testify v1.8.0
 )
 
-go 1.16
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+go 1.19

--- a/main.go
+++ b/main.go
@@ -133,6 +133,7 @@ func provideServerHandler(config testAppConfig, cancel context.CancelFunc) http.
 
 	// Demo Server Routes
 	r.Use(server.DelayMiddleware)
+	r.Use(server.ReadRequestBodyMiddleware)
 	r.Use(handlers.CompressHandler)
 	server.RegisterTestAppRoutes(r)
 	if !config.DisableTLS {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -21,6 +22,18 @@ func DelayMiddleware(next http.Handler) http.Handler {
 				case <-r.Context().Done():
 				}
 			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func ReadRequestBodyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if r.URL.Query().Has("read-body") {
+			logrus.Debug("Reading request body")
+			io.Copy(io.Discard, r.Body)
 		}
 
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
When a request is made with `read-body` as a query parameter, this middleware will read (and discard) the body. This can be used for slow upload testing and other cases.